### PR TITLE
Spock 1.2 annotations and Mocking a Spring Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 /build/
 !gradle/wrapper/gradle-wrapper.jar
+out
 
 ### NPM ###
 /npm-debug.log

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Thankfully Spock 1.1 introduced the `DetachedMockFactory`. This, combined with t
 The heart of this example lives in our `PersonControllerIntTest`.  The `PersonControllerIntTest` spins up a Spring context so we can make a `MockMvc` call to a REST endpoint which pulls data from an h2 database via a Spring Data repo, but the "Rank" data we would normally get from an external service has been mocked.
 
 Updates:
-* Spock 1.2 provides new @SpringSpy and @SpringBean annotations to make injecting mocks even easier.
+* Spock 1.2 provides new @SpringBean, @SpringSpy, and @UnwrapAopProxy annotations to make injecting mocks even easier.
 * Mocking Spring proxied objects, like @Validated or @Repository, requires unwrapping the proxy to use the mock objects
 
 Testing provided by Travis CI 

--- a/README.md
+++ b/README.md
@@ -10,5 +10,9 @@ Thankfully Spock 1.1 introduced the `DetachedMockFactory`. This, combined with t
 
 The heart of this example lives in our `PersonControllerIntTest`.  The `PersonControllerIntTest` spins up a Spring context so we can make a `MockMvc` call to a REST endpoint which pulls data from an h2 database via a Spring Data repo, but the "Rank" data we would normally get from an external service has been mocked.
 
+Updates:
+* Spock 1.2 provides new @SpringSpy and @SpringBean annotations to make injecting mocks even easier.
+* Mocking Spring proxied objects, like @Validated or @Repository, requires unwrapping the proxy to use the mock objects
+
 Testing provided by Travis CI 
 [![Build Status](https://travis-ci.org/snekse/spring-spock-integration-testing.svg?branch=master)](https://travis-ci.org/snekse/spring-spock-integration-testing)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 **This is a Spock 1.2 update of the original fork**
 
+Original blog post here: https://objectpartners.com/2017/04/18/spring-integration-testing-with-spock-mocks/
+
+Original source code here: https://github.com/snekse/spring-spock-integration-testing
+
 **How to inject Spock mocks into Spring integration tests**
 
 This project is intended to be used as en example guide to illustrate how you can use Spock with Spring (and Spring Boot) with a mix of Spring configuration and Spock mocks.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**This is a Spock 1.2 update of the original fork**
+**This is a Spock 1.2 update of the original code from Derek Eskens @snekse**
 
 Original blog post here: https://objectpartners.com/2017/04/18/spring-integration-testing-with-spock-mocks/
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This is a Spock 1.2 update of the original fork**
+
 **How to inject Spock mocks into Spring integration tests**
 
 This project is intended to be used as en example guide to illustrate how you can use Spock with Spring (and Spring Boot) with a mix of Spring configuration and Spock mocks.
@@ -11,8 +13,5 @@ Thankfully Spock 1.1 introduced the `DetachedMockFactory`. This, combined with t
 The heart of this example lives in our `PersonControllerIntTest`.  The `PersonControllerIntTest` spins up a Spring context so we can make a `MockMvc` call to a REST endpoint which pulls data from an h2 database via a Spring Data repo, but the "Rank" data we would normally get from an external service has been mocked.
 
 Updates:
-* Spock 1.2 provides new @SpringBean, @SpringSpy, and @UnwrapAopProxy annotations to make injecting mocks even easier.
+* Spock 1.2 provides new @SpringBean, @SpringSpy, and @UnwrapAopProxy annotations to make injecting mocks even easier. See `PersonControllerIntSpock12Test`
 * Mocking Spring proxied objects, like @Validated or @Repository, requires unwrapping the proxy to use the mock objects
-
-Testing provided by Travis CI 
-[![Build Status](https://travis-ci.org/snekse/spring-spock-integration-testing.svg?branch=master)](https://travis-ci.org/snekse/spring-spock-integration-testing)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '1.5.2.RELEASE'
+		springBootVersion = '1.5.13.RELEASE'
 	}
 	repositories {
 		mavenCentral()
@@ -21,6 +21,11 @@ sourceCompatibility = 1.8
 
 repositories {
 	jcenter()
+
+	maven {
+		//Required until Spock 1.2 is released out of snapshot
+		url 'https://oss.sonatype.org/content/repositories/snapshots/'
+	}
 }
 
 
@@ -30,12 +35,12 @@ dependencies {
 	compile('org.codehaus.groovy:groovy')
 	runtime('com.h2database:h2')
 
-    def spockVersion = '1.1-groovy-2.4-rc-4'
+    def spockVersion = '1.2-groovy-2.4-SNAPSHOT'
 
 	testCompile("org.springframework.boot:spring-boot-starter-test")
 	testCompile("org.spockframework:spock-core:$spockVersion")
     testCompile("org.spockframework:spock-spring:$spockVersion")
 	testCompile("com.blogspot.toomuchcoding:spock-subjects-collaborators-extension:1.2.1")
     // needed for mocking in Spock
-    testCompile("cglib:cglib-nodep:2.2")
+    testCompile("cglib:cglib-nodep:3.2.1")
 }

--- a/src/main/groovy/com/objectpartners/eskens/controllers/PersonController.groovy
+++ b/src/main/groovy/com/objectpartners/eskens/controllers/PersonController.groovy
@@ -1,7 +1,7 @@
 package com.objectpartners.eskens.controllers
 
+import com.objectpartners.eskens.model.Rank
 import com.objectpartners.eskens.services.PersonService
-import com.objectpartners.eskens.services.Rank
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,6 +22,13 @@ class PersonController {
     String getNameAndRank(@PathVariable(name = 'id') Long id ) {
         def name = personService.getAddressToForPersonId(id)
         Rank rank = personService.getRank(id)
+        return "$name ~ $rank.classification:Level $rank.level"
+    }
+
+    @GetMapping(path = '{id}/validatedRank')
+    String getNameAndValidatedRank(@PathVariable(name = 'id') Long id ) {
+        def name = personService.getAddressToForPersonId(id)
+        Rank rank = personService.getValidatedRank(id)
         return "$name ~ $rank.classification:Level $rank.level"
     }
 }

--- a/src/main/groovy/com/objectpartners/eskens/model/Rank.groovy
+++ b/src/main/groovy/com/objectpartners/eskens/model/Rank.groovy
@@ -1,0 +1,6 @@
+package com.objectpartners.eskens.model
+
+class Rank {
+    int level
+    String classification
+}

--- a/src/main/groovy/com/objectpartners/eskens/services/ExternalRankingService.groovy
+++ b/src/main/groovy/com/objectpartners/eskens/services/ExternalRankingService.groovy
@@ -2,12 +2,14 @@ package com.objectpartners.eskens.services
 
 import com.objectpartners.eskens.entities.Person
 import org.springframework.stereotype.Service
+import org.springframework.validation.annotation.Validated
 
 /**
  * This is to mimic calls to an external 3rd party service that you wouldn't want to test locally.
  * Created by derek on 4/10/17.
  */
 @Service
+@Validated
 class ExternalRankingService {
 
     @SuppressWarnings("GrMethodMayBeStatic")

--- a/src/main/groovy/com/objectpartners/eskens/services/ExternalRankingService.groovy
+++ b/src/main/groovy/com/objectpartners/eskens/services/ExternalRankingService.groovy
@@ -3,10 +3,10 @@ package com.objectpartners.eskens.services
 import com.objectpartners.eskens.entities.Person
 import com.objectpartners.eskens.model.Rank
 import org.springframework.stereotype.Service
-import org.springframework.validation.annotation.Validated
 
 /**
  * This is to mimic calls to an external 3rd party service that you wouldn't want to test locally.
+ * Created by derek on 4/10/17.
  */
 @Service
 class ExternalRankingService {

--- a/src/main/groovy/com/objectpartners/eskens/services/ExternalRankingService.groovy
+++ b/src/main/groovy/com/objectpartners/eskens/services/ExternalRankingService.groovy
@@ -6,10 +6,9 @@ import org.springframework.validation.annotation.Validated
 
 /**
  * This is to mimic calls to an external 3rd party service that you wouldn't want to test locally.
- * Created by derek on 4/10/17.
  */
 @Service
-@Validated
+@Validated //This makes it a spring proxied service, so unwrapping is necessary to use a Mock
 class ExternalRankingService {
 
     @SuppressWarnings("GrMethodMayBeStatic")

--- a/src/main/groovy/com/objectpartners/eskens/services/PersonService.groovy
+++ b/src/main/groovy/com/objectpartners/eskens/services/PersonService.groovy
@@ -1,6 +1,7 @@
 package com.objectpartners.eskens.services
 
 import com.objectpartners.eskens.entities.Person
+import com.objectpartners.eskens.model.Rank
 import com.objectpartners.eskens.repos.PersonRepo
 import org.springframework.stereotype.Service
 
@@ -11,9 +12,12 @@ class PersonService {
 
     final ExternalRankingService externalRankingService
 
-    PersonService(PersonRepo pr, ExternalRankingService ers) {
+    final ValidatedExternalRankingService validatedExternalRankingService
+
+    PersonService(PersonRepo pr, ExternalRankingService ers, ValidatedExternalRankingService vers) {
         this.personRepo = pr
         this.externalRankingService = ers
+        this.validatedExternalRankingService = vers
     }
 
     String getAddressToForPersonId(Long personId) {
@@ -23,6 +27,10 @@ class PersonService {
 
     Rank getRank(Long personId) {
         externalRankingService.getRank(getPerson(personId))
+    }
+
+    Rank getValidatedRank(Long personId) {
+        validatedExternalRankingService.getRank(getPerson(personId))
     }
 
     private Person getPerson(Long personId) {

--- a/src/main/groovy/com/objectpartners/eskens/services/ValidatedExternalRankingService.groovy
+++ b/src/main/groovy/com/objectpartners/eskens/services/ValidatedExternalRankingService.groovy
@@ -6,10 +6,12 @@ import org.springframework.stereotype.Service
 import org.springframework.validation.annotation.Validated
 
 /**
- * This is to mimic calls to an external 3rd party service that you wouldn't want to test locally.
+ * This class is @Validated, which makes it a spring proxied service
+ *   so unwrapping is necessary to use a Mock
  */
 @Service
-class ExternalRankingService {
+@Validated
+class ValidatedExternalRankingService {
 
     @SuppressWarnings("GrMethodMayBeStatic")
     Rank getRank(Person person) {

--- a/src/test/groovy/com/objectpartners/eskens/config/IntegrationTestMockingConfig.groovy
+++ b/src/test/groovy/com/objectpartners/eskens/config/IntegrationTestMockingConfig.groovy
@@ -1,6 +1,7 @@
 package com.objectpartners.eskens.config
 
 import com.objectpartners.eskens.services.ExternalRankingService
+import com.objectpartners.eskens.services.ValidatedExternalRankingService
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import spock.mock.DetachedMockFactory
@@ -17,5 +18,10 @@ class IntegrationTestMockingConfig {
     @Bean
     ExternalRankingService externalRankingService() {
         factory.Mock(ExternalRankingService)
+    }
+
+    @Bean
+    ValidatedExternalRankingService validatedExternalRankingService() {
+        factory.Mock(ValidatedExternalRankingService)
     }
 }

--- a/src/test/groovy/com/objectpartners/eskens/services/PersonServiceTest.groovy
+++ b/src/test/groovy/com/objectpartners/eskens/services/PersonServiceTest.groovy
@@ -3,6 +3,7 @@ package com.objectpartners.eskens.services
 import com.blogspot.toomuchcoding.spock.subjcollabs.Collaborator
 import com.blogspot.toomuchcoding.spock.subjcollabs.Subject
 import com.objectpartners.eskens.entities.Person
+import com.objectpartners.eskens.model.Rank
 import com.objectpartners.eskens.repos.PersonRepo
 import spock.lang.Specification
 


### PR DESCRIPTION
For a new blog post to show how to use the new Spock 1.2 annotations, I thought it might be easiest to just update and reference the examples that you had previously created. I hope this is okay?

Let me know your thoughts, and if you see anything that I can improve on!

The whole ValidatedExternalRankingService is kind of a stretch, but I think it is nice to compare with what the normal ExternalRankingService mock method is.